### PR TITLE
Fix iOS installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@
 
 `$ npm install @wootric/react-native-wootric --save`
 
-### Mostly automatic installation
+### iOS
+
+Install the `WootricSDK` using Cocoapods
+
+```bash
+$ cd ios
+$ pod install
+```
+
+### ReactNative <= 0.60
 
 As `@wootric/react-native-wootric` contains native codes so requires your project to link our native module library:
 

--- a/RNWootric.podspec
+++ b/RNWootric.podspec
@@ -6,13 +6,12 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNWootric
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://wootric.com"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.author       = { "Wootric" => "support@wootric.com" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNWootric.git", :tag => "master" }
-  s.source_files  = "RNWootric/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/Wootric/RNWootric.git", :tag => s.version.to_s }
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
 


### PR DESCRIPTION
Fix installation of iOS

## Changes

- Fix RNWootric.podspec
- Update `README`

## Test

1. Create a ReactNative app

```bash
$ npx react-native init TestApp
$ cd TestApp
```

2. Add the library from this branch

```bash
$ npm install git://github.com/Wootric/react-native-wootric.git#ds-fix-ios --save 
```

3. Install `WootricSDK` with Cocoapods

```bash
$ cd ios
$ pod install
```

4. Modify `App.js` file:

```js
import RNWootric from '@wootric/react-native-wootric';

RNWootric.configureWithClientID(YOUR_CLIENT_ID, YOUR_ACCOUNT_TOKEN);
RNWootric.setSurveyImmediately(true);
RNWootric.setEndUserEmail("test@email.com");
RNWootric.setEndUserCreatedAt(1234567890);
RNWootric.setEndUserProperties({platform: "React Native"});
RNWootric.showSurvey();
```

4. Run app in iOS

```bash
$ npx react-native run-ios
```