### PR TITLE
Fix survey not showing up & add forceSurvey method

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest package="com.reactlibrary">
+<manifest package="com.reactlibrary.wootric">
 
 </manifest>
   

--- a/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
@@ -1,4 +1,6 @@
-package com.reactlibrary;
+package com.reactlibrary.wootric;
+
+import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 import android.app.Activity;
 import android.util.Log;
@@ -39,7 +41,7 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
           map.put(key, Boolean.toString(readableMap.getBoolean(key)));
           break;
         case Number:
-          map.put(key, Double.toString(readableMap.getDouble(key)));
+          map.put(key, Integer.toString(readableMap.getInt(key)));
           break;
         case String:
           map.put(key, readableMap.getString(key));
@@ -149,11 +151,21 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void forceSurvey(boolean force) {
+    // Workaround for Android
+    this.setSurveyImmediately(force);
+  }
+
+  @ReactMethod
   public void showSurvey() {
     if (wootric == null) return;
 
     try {
-      wootric.survey();
+      runOnUiThread (new Thread(new Runnable() {
+        public void run() {
+          wootric.survey();
+        }
+      }));
     } catch (Exception e) {
       Log.e("WOOTRIC", e.toString());
     }

--- a/android/src/main/java/com/reactlibrary/wootric/RNWootricPackage.java
+++ b/android/src/main/java/com/reactlibrary/wootric/RNWootricPackage.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.reactlibrary.wootric;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;

--- a/ios/RNWootric.m
+++ b/ios/RNWootric.m
@@ -58,6 +58,10 @@ RCT_EXPORT_METHOD(setCustomAudience:(NSString *)audience) {
   [Wootric setCustomAudience:audience];
 }
 
+RCT_EXPORT_METHOD(forceSurvey:(BOOL)force) {
+  [Wootric forceSurvey:force];
+}
+
 RCT_EXPORT_METHOD(showSurvey) {
   [Wootric showSurveyInViewController:[UIApplication sharedApplication].delegate.window.rootViewController];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wootric/react-native-wootric",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix Android error preventing survey to show up `java.lang.IllegalStateException: Method addObserver must be called on the main thread` and add `forceSurvey` method

## Test

1. Create a ReactNative app

```bash
$ npx react-native init TestApp
$ cd TestApp
```

2. Add the library from this branch

```bash
$ npm install https://github.com/Wootric/react-native-wootric.git#ds-update-library --save
```

3. Modify `App.js` file:

```js
import RNWootric from '@wootric/react-native-wootric';

RNWootric.configureWithClientID(YOUR_CLIENT_ID, YOUR_ACCOUNT_TOKEN);
RNWootric.setSurveyImmediately(true);
RNWootric.setEndUserEmail("test@email.com");
RNWootric.setEndUserCreatedAt(1234567890);
RNWootric.setEndUserProperties({platform: "React Native"});
RNWootric.showSurvey();
```

4. Run app in Android

```bash
$ npx react-native run-android
```