### PR TITLE
feat: expose passive and promoter custom thank you methods

### DIFF
--- a/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
@@ -4,6 +4,7 @@ import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 import android.app.Activity;
 import android.util.Log;
+import android.net.Uri;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -12,6 +13,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import com.wootric.androidsdk.Wootric;
+import com.wootric.androidsdk.Wootric;
+import com.wootric.androidsdk.objects.WootricCustomThankYou;
 
 import java.util.HashMap;
 
@@ -169,5 +172,29 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
     } catch (Exception e) {
       Log.e("WOOTRIC", e.toString());
     }
+  }
+
+  @ReactMethod
+  public void setPromoterThankYouLinkWithText(String promoterLinkText, String promoterLinkUri ) {
+
+    WootricCustomThankYou customThankYou = new WootricCustomThankYou();
+
+    customThankYou.setPromoterLinkUri(Uri.parse(promoterLinkUri));
+    customThankYou.setPromoterLinkText(promoterLinkText);
+
+    if (wootric == null) return;
+    wootric.setCustomThankYou(customThankYou);
+  }
+
+  @ReactMethod
+  public void setPassiveThankYouLinkWithText(String passiveLinkText, String passiveLinkUri ) {
+
+    WootricCustomThankYou customThankYou = new WootricCustomThankYou();
+
+    customThankYou.setPassiveLinkUri(Uri.parse(passiveLinkUri));
+    customThankYou.setPassiveLinkText(passiveLinkText);
+    
+    if (wootric == null) return;
+    wootric.setCustomThankYou(customThankYou);
   }
 }

--- a/ios/RNWootric.m
+++ b/ios/RNWootric.m
@@ -65,5 +65,13 @@ RCT_EXPORT_METHOD(forceSurvey:(BOOL)force) {
 RCT_EXPORT_METHOD(showSurvey) {
   [Wootric showSurveyInViewController:[UIApplication sharedApplication].delegate.window.rootViewController];
 }
+
+RCT_EXPORT_METHOD(setPromoterThankYouLinkWithText:(NSString *)text url:(NSURL *)URL) {
+  [Wootric setPromoterThankYouLinkWithText:text URL:URL];
+}
+
+RCT_EXPORT_METHOD(setPassiveThankYouLinkWithText:(NSString *)text url:(NSURL *)URL) {
+  [Wootric setPassiveThankYouLinkWithText:text URL:URL];
+}
 @end
   


### PR DESCRIPTION
Expose methods to set custom thank you links for passive and promoter users on both platforms.

The methods can be used as follow:
```
  RNWootric.setPromoterThankYouLinkWithText(
    'thank you promoter',
    'https://thank-you-promoter'
  )
  RNWootric.setPassiveThankYouLinkWithText(
    'thank you passive',
    'https://thank-you-passive'
  )
```