### PR TITLE
Add Event Based Sampling support

### DIFF
--- a/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
@@ -151,6 +151,13 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void setEventName(String eventName) {
+    if (wootric == null) return;
+
+    wootric.setEventName(eventName);
+  }
+
+  @ReactMethod
   public void forceSurvey(boolean force) {
     // Workaround for Android
     this.setSurveyImmediately(force);

--- a/ios/RNWootric.m
+++ b/ios/RNWootric.m
@@ -42,6 +42,10 @@ RCT_EXPORT_METHOD(showOptOut:(BOOL)flag) {
   [Wootric showOptOut:flag];
 }
 
+RCT_EXPORT_METHOD(setEventName:(NSString *)eventName) {
+  [Wootric setEventName:eventName];
+}
+
 RCT_EXPORT_METHOD(setFirstSurveyAfter:(nonnull NSNumber *)firstSurveyAfter) {
   [Wootric setFirstSurveyAfter:firstSurveyAfter];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wootric/react-native-wootric",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add support for events.

## Test

1. Create a ReactNative app

```bash
$ npx react-native init TestApp
$ cd TestApp
```

2. Add the library from this branch

```bash
$ npm install https://github.com/Wootric/react-native-wootric.git#ds-add-ebs --save
```

3. Modify `App.js` file:

```js
import RNWootric from '@wootric/react-native-wootric';

RNWootric.configureWithClientID(YOUR_CLIENT_ID, YOUR_ACCOUNT_TOKEN);
RNWootric.setSurveyImmediately(true);
RNWootric.setEndUserEmail("test@email.com");
RNWootric.setEndUserCreatedAt(1234567890);
RNWootric.setEndUserProperties({platform: "React Native"});
RNWootric.setEventName("your_event_name");
RNWootric.showSurvey();
```

4. Run app in Android & iOS

```bash
$ npx react-native run-android
$ npx react-native run-ios
```