### PR TITLE
Add disclaimer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ RNWootric.setFirstSurveyAfter(5);
 RNWootric.setCustomLanguage("ES");
 RNWootric.setCustomProductName("Wootric React Native");
 RNWootric.setCustomAudience("un amigo");
+RNWootric.showDisclaimerText("Learn how we handle your feedback","https://example.com/terms-of-use","here");
 RNWootric.showSurvey();
 ```
 

--- a/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/wootric/RNWootricModule.java
@@ -4,6 +4,7 @@ import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 import android.app.Activity;
 import android.util.Log;
+import android.net.Uri;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -155,6 +156,14 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
     if (wootric == null) return;
 
     wootric.setEventName(eventName);
+  }
+
+  @ReactMethod
+  public void showDisclaimerText(String disclaimerText, String disclaimerLinkURL, String disclaimerLinkText) {
+    if (wootric == null) return;
+
+    Uri disclaimerLinkURI = Uri.parse(disclaimerLinkURL);
+    wootric.showDisclaimer(disclaimerText, disclaimerLinkURI, disclaimerLinkText);
   }
 
   @ReactMethod

--- a/ios/RNWootric.m
+++ b/ios/RNWootric.m
@@ -62,6 +62,10 @@ RCT_EXPORT_METHOD(setCustomAudience:(NSString *)audience) {
   [Wootric setCustomAudience:audience];
 }
 
+RCT_EXPORT_METHOD(showDisclaimerText:(NSString *)disclaimerText link:(NSURL *)link linkText:(NSString *)linkText) {
+  [Wootric showDisclaimerText:disclaimerText link:link linkText:linkText];
+}
+
 RCT_EXPORT_METHOD(forceSurvey:(BOOL)force) {
   [Wootric forceSurvey:force];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wootric/react-native-wootric",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add support to show disclaimer text with link at the bottom of the survey.

## Test

1. Create a ReactNative app

```bash
$ npx react-native init TestApp
$ cd TestApp
```

2. Add the library from this branch

```bash
npm install https://github.com/Wootric/react-native-wootric.git#ds-DEV-41563-disclaimer --save
```

3. Modify `App.js` file:

```js
import RNWootric from '@wootric/react-native-wootric';

RNWootric.configureWithClientID(YOUR_CLIENT_ID, YOUR_ACCOUNT_TOKEN);
RNWootric.setSurveyImmediately(true);
RNWootric.setEndUserEmail("test@email.com");
RNWootric.setEndUserCreatedAt(1234567890);
RNWootric.setEndUserProperties({platform: "React Native"});
RNWootric.showDisclaimerText("Learn how we handle your feedback","https://inmoment.com/terms-of-use/","here");
RNWootric.showSurvey();
```

4. Run app in Android & iOS

```bash
$ npx react-native run-android
$ npx react-native run-ios
```